### PR TITLE
Add Google Analytics tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,16 @@
     <meta name="robots" content="index, follow">
     <link rel="canonical" href="https://de-mololoog.be/" />
     
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-NHWCJ985YQ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+    
+      gtag('config', 'G-NHWCJ985YQ');
+    </script>
+    
     <!-- Primary Meta Tags -->
     <title>De Mololoog - De leukste Vlaamse nabespreking podcast over De Mol</title>
     <meta name="title" content="De Mololoog - De leukste Vlaamse nabespreking podcast over De Mol">


### PR DESCRIPTION
This PR adds Google Analytics tracking to the website to help monitor traffic and user behavior.

Changes:
- Added Google Analytics tracking script to index.html
- Added gtag.js configuration with tracking ID