### PR TITLE
Add YouTube Music button and update favicon links

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/images/de-mololoog-icon.png" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="language" content="Dutch">
     <meta name="geo.region" content="BE" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ function App() {
           </a>
 
           {/* Other Platform Links */}
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-4 gap-3">
             <a 
               href="https://podcasts.apple.com/us/podcast/de-mololoog/id1807142206" 
               className="flex flex-col items-center gap-0 bg-[#024D6C] hover:bg-[#035d84] px-4 py-2 rounded-lg transition-colors text-center group"
@@ -80,6 +80,15 @@ function App() {
             >
               <span className="text-base font-semibold whitespace-nowrap">Pocket</span>
               <span className="text-base font-semibold whitespace-nowrap">Casts</span>
+            </a>
+            <a 
+              href="https://music.youtube.com/playlist?list=PLqUfKQeHXBR5iJ6OMdgXrUJBJWJCAShGp" 
+              className="flex flex-col items-center gap-0 bg-[#024D6C] hover:bg-[#035d84] px-4 py-2 rounded-lg transition-colors text-center group"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <span className="text-base font-semibold whitespace-nowrap">YouTube</span>
+              <span className="text-base font-semibold whitespace-nowrap">Music</span>
             </a>
             <a 
               href="https://anchor.fm/s/1035d87f8/podcast/rss" 


### PR DESCRIPTION
This PR adds a YouTube Music button to the platform links and updates the favicon configuration.

Changes:
- Added YouTube Music button to the platform links grid
- Changed grid from 3 to 4 columns
- Added additional favicon links for better cross-platform support